### PR TITLE
Comment commit msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,37 @@
 # pre-commit prepend jira issue
 
-A [pre-commit](https://pre-commit.com/) hook to prepend a Jira issue to a commit message, extracted from the branch name.
+A [pre-commit](https://pre-commit.com/) hook to prepend a Jira issue to a commit message, extracted from the current branch name.
 
 ## Usage
 
-todo
+1. Install [`pre-commit`](https://pre-commit.com/) if it's not already installed
+
+    Globally with [`pipx`](https://github.com/pypa/pipx):
+
+    ```command
+    pipx install pre-commit
+    ```
+
+    Or one of the ways mentioned in the pre-commit [installation docs](https://pre-commit.com/#installation).
+
+2. Add this hook to your `.pre-commit-config.yaml` file.
+
+    ```yaml
+    repos:
+    - repo: https://github.com/falkben/pre-commit-prepend-jira-issue
+        rev: v0.0.1
+        hooks:
+        - id: prepend-jira-issue
+            stages: [commit-msg]
+    ```
+
+3. Install the hook
+
+    ```command
+    pre-commit install --hook-type commit-msg
+    ```
+
+4. Commit the `.pre-commit-config.yaml` to your repo.
 
 ## License
 

--- a/prepend_jira_issue.py
+++ b/prepend_jira_issue.py
@@ -35,9 +35,23 @@ def extract_jira_issue(content: str) -> str | None:
 
 
 def get_commit_msg(commit_msg_filepath: str) -> str:
+    """Get the commit message
+
+    Ignore comment lines as those aren't included in the commit message
+    """
+
+    # todo: instead of removing comment lines from the commit message, we should instead
+    # skip them in our regex search
     with open(commit_msg_filepath) as f:
-        msg = f.read()
+        msg = ""
+        for line in f:
+            if not line.startswith("#"):
+                msg += line
     return msg
+
+
+def prepend_jira_issue(msg: str, issue: str) -> str:
+    return f"{issue}: {msg}"
 
 
 def write_commit_msg(commit_msg_filepath: str, commit_msg: str) -> None:
@@ -70,8 +84,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if commit_msg_jira_issue:
         return 0
 
-    # prepend the jira issue to the commit message if it's missing
-    new_commit_msg = f"{branch_jira_issue}: {commit_msg}"
+    new_commit_msg = prepend_jira_issue(commit_msg, branch_jira_issue)
+
     write_commit_msg(args.commit_msg_filepath, new_commit_msg)
 
     return 0

--- a/test_prepend_jira_ticket.py
+++ b/test_prepend_jira_ticket.py
@@ -1,6 +1,55 @@
+from pathlib import Path
+
 import pytest
 
 import prepend_jira_issue
+
+LONG_COMMIT_MSG = """\
+spanning many lines
+
+a very long commit message
+
+i am a haiku
+"""
+SHORT_COMMIT_MSG = "a short commit msg"
+COMMENTED_COMMIT_MSG = """\
+This is the commit message
+
+Not the stuff below
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch ABC-111
+# Untracked files:
+#	a-file.txt
+#
+"""
+
+
+@pytest.fixture
+def create_commit_msg_file(tmp_path: Path):
+    """Fixture factory for creating a commit message file
+
+    Defaults to creating a file containing short commit message but can pass in a custom
+    commit message
+
+    Ex:
+
+    ```python
+    def test_get_commit_msg_long(create_commit_msg_file):
+        long_commit_msg_file = create_commit_msg_file(LONG_COMMIT_MSG)
+    ```
+    """
+
+    def _commit_msg_file(
+        commit_msg: str = SHORT_COMMIT_MSG,
+    ):
+
+        f = tmp_path / "commit_msg"
+        f.write_text(commit_msg)
+        return str(f)
+
+    yield _commit_msg_file
 
 
 @pytest.mark.parametrize(
@@ -22,3 +71,44 @@ import prepend_jira_issue
 def test_extract_jira_issue(content, expected):
     output = prepend_jira_issue.extract_jira_issue(content)
     assert output == expected
+
+
+def test_get_commit_msg_long(create_commit_msg_file):
+    long_commit_msg_file = create_commit_msg_file(LONG_COMMIT_MSG)
+
+    msg = prepend_jira_issue.get_commit_msg(long_commit_msg_file)
+    assert msg == LONG_COMMIT_MSG
+
+
+def test_get_commit_msg_short(create_commit_msg_file):
+    short_commit_msg_file = create_commit_msg_file(SHORT_COMMIT_MSG)
+
+    msg = prepend_jira_issue.get_commit_msg(short_commit_msg_file)
+    assert msg == SHORT_COMMIT_MSG
+
+
+def test_get_commit_msg_commented(create_commit_msg_file):
+    commented_commit_msg_file = create_commit_msg_file(COMMENTED_COMMIT_MSG)
+
+    expected_msg = """\
+This is the commit message
+
+Not the stuff below
+"""
+
+    msg = prepend_jira_issue.get_commit_msg(commented_commit_msg_file)
+    assert msg == expected_msg
+
+
+def test_prepend_jira_issue_short_msg():
+    issue = "some_issue"
+    new_msg = prepend_jira_issue.prepend_jira_issue(SHORT_COMMIT_MSG, issue)
+
+    assert new_msg == f"some_issue: {SHORT_COMMIT_MSG}"
+
+
+def test_prepend_jira_issue_long_msg():
+    issue = "some_issue"
+    new_msg = prepend_jira_issue.prepend_jira_issue(LONG_COMMIT_MSG, issue)
+
+    assert new_msg == f"some_issue: {LONG_COMMIT_MSG}"


### PR DESCRIPTION
commit messages with comments (which can occur with commit messages created with the editor) include the branch name in the comments, which would contain the jira issue. we need to ignore the commented lines so that our check to determine if the jira issue is already in the commit message doesn't falsely trigger (skipping prepend).

since commented commit message lines aren't included in the commit message anyways, this PR removes those comments from the commit message during processing

We may consider adjusting our regex to avoid searching on comment lines, as some may use commit message comment lines for something (a later hook?)

however, my initial regex attempt wasn't pulling the issue out correctly:

```
^(?!#).+([A-Z]{2,}-[0-9]+)
```

--- doing a negative lookahead to determine if line starts with `#`